### PR TITLE
v1.0.3: fix rails 6 reloader

### DIFF
--- a/lib/dhs.rb
+++ b/lib/dhs.rb
@@ -58,10 +58,12 @@ module DHS
   autoload :Unprocessable, 'dhs/unprocessable'
 
   include Configuration
-  include AutoloadRecords if defined?(Rails)
   include OptionBlocks
 
   require 'dhs/record' # as dhs records in an application are directly inheriting it
 
-  require 'dhs/railtie' if defined?(Rails)
+  if defined?(Rails)
+    include AutoloadRecords
+    require 'dhs/railtie'
+  end
 end

--- a/lib/dhs/concerns/autoload_records.rb
+++ b/lib/dhs/concerns/autoload_records.rb
@@ -18,6 +18,9 @@ module AutoloadRecords
       end
 
       class Middleware
+
+        MODEL_FILES = 'app/models/**/*.rb'.freeze
+
         def initialize(app)
           @app = app
         end
@@ -27,24 +30,25 @@ module AutoloadRecords
           @app.call(env)
         end
 
-        def self.model_files
-          Dir.glob(Rails.root.join('app', 'models', '**', '*.rb'))
-        end
 
         def self.require_direct_inheritance
-          model_files.sort.map do |file|
-            next unless File.read(file).match('DHS::Record')
-            require_dependency file
-            file.split('models/').last.gsub('.rb', '').classify
-          end.compact
+          Rails.application.reloader.to_prepare do
+            Dir.glob(Rails.root.join(MODEL_FILES)).each do |file|
+              next unless File.read(file).match('DHS::Record')
+              require_dependency file
+              file.split('models/').last.gsub('.rb', '').classify
+            end.compact
+          end
         end
 
         def self.require_inheriting_records(parents)
-          model_files.each do |file|
-            file_content = File.read(file)
-            next if parents.none? { |parent| file_content.match(/\b#{parent}\b/) }
-            next if file_content.match?('extend ActiveSupport::Concern')
-            require_dependency file
+          Rails.application.reloader.to_prepare do
+            Dir.glob(Rails.root.join(MODEL_FILES)).each do |file|
+              file_content = File.read(file)
+              next if parents.none? { |parent| file_content.match(/\b#{parent}\b/) }
+              next if file_content.match?('extend ActiveSupport::Concern')
+              require_dependency file
+            end
           end
         end
 

--- a/lib/dhs/concerns/autoload_records.rb
+++ b/lib/dhs/concerns/autoload_records.rb
@@ -19,7 +19,7 @@ module AutoloadRecords
 
       class Middleware
 
-        MODEL_FILES = 'app/models/**/*.rb'.freeze
+        MODEL_FILES = 'app/models/**/*.rb'
 
         def initialize(app)
           @app = app
@@ -29,7 +29,6 @@ module AutoloadRecords
           self.class.require_records
           @app.call(env)
         end
-
 
         def self.require_direct_inheritance
           Rails.application.reloader.to_prepare do

--- a/lib/dhs/railtie.rb
+++ b/lib/dhs/railtie.rb
@@ -3,7 +3,6 @@
 module DHS
   class Railtie < Rails::Railtie
     initializer 'dhs.hook_into_controller_initialization' do
-
       Rails.application.reloader.to_prepare do
         require_relative 'railtie/action_controller_extension'
       end

--- a/lib/dhs/railtie.rb
+++ b/lib/dhs/railtie.rb
@@ -3,31 +3,9 @@
 module DHS
   class Railtie < Rails::Railtie
     initializer 'dhs.hook_into_controller_initialization' do
-      class ActionController::Base
 
-        def initialize
-          prepare_dhs_request_cycle_cache
-          reset_option_blocks
-          reset_extended_rollbar_request_logs
-          super
-        end
-
-        private
-
-        def prepare_dhs_request_cycle_cache
-          return unless DHS.config.request_cycle_cache_enabled
-          DHS::Interceptors::RequestCycleCache::ThreadRegistry.request_id = [Time.now.to_f, request.object_id].join('#')
-        end
-
-        def reset_option_blocks
-          DHS::OptionBlocks::CurrentOptionBlock.options = nil
-        end
-
-        def reset_extended_rollbar_request_logs
-          return unless defined?(::Rollbar)
-          return unless DHC.config.interceptors.include?(DHS::Interceptors::ExtendedRollbar::Interceptor)
-          DHS::Interceptors::ExtendedRollbar::ThreadRegistry.log = []
-        end
+      Rails.application.reloader.to_prepare do
+        require_relative 'railtie/action_controller_extension'
       end
     end
   end

--- a/lib/dhs/railtie/action_controller_extension.rb
+++ b/lib/dhs/railtie/action_controller_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DHS
   class Railtie < Rails::Railtie
 
@@ -27,6 +29,6 @@ module DHS
         DHS::Interceptors::ExtendedRollbar::ThreadRegistry.log = []
       end
     end
-    
+
   end
 end

--- a/lib/dhs/railtie/action_controller_extension.rb
+++ b/lib/dhs/railtie/action_controller_extension.rb
@@ -1,0 +1,32 @@
+module DHS
+  class Railtie < Rails::Railtie
+
+    class ::ActionController::Base
+
+      def initialize
+        prepare_dhs_request_cycle_cache
+        reset_option_blocks
+        reset_extended_rollbar_request_logs
+        super
+      end
+
+      private
+
+      def prepare_dhs_request_cycle_cache
+        return unless DHS.config.request_cycle_cache_enabled
+        DHS::Interceptors::RequestCycleCache::ThreadRegistry.request_id = [Time.now.to_f, request.object_id].join('#')
+      end
+
+      def reset_option_blocks
+        DHS::OptionBlocks::CurrentOptionBlock.options = nil
+      end
+
+      def reset_extended_rollbar_request_logs
+        return unless defined?(::Rollbar)
+        return unless DHC.config.interceptors.include?(DHS::Interceptors::ExtendedRollbar::Interceptor)
+        DHS::Interceptors::ExtendedRollbar::ThreadRegistry.log = []
+      end
+    end
+    
+  end
+end

--- a/lib/dhs/version.rb
+++ b/lib/dhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DHS
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
Rails 6 starts new autoloading/reloading behavior.

This PR fixes the deprecation warnings mentioned here: https://github.com/local-ch/lhs/issues/404